### PR TITLE
avoid loading pkg until needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version:
-          - "nightly"
-        os:
-          - ubuntu-latest
-        julia-arch:
-          - x64
+        include:
+          - os: ubuntu-latest
+            julia-arch: x64
+            julia-version: 'nightly'
+          - os: windows-latest
+            julia-arch: x64
+            julia-version: 'nightly'
+          - os: macos-latest
+            julia-arch: aarch64
+            julia-version: 'nightly'
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-uploadcodecov@v0.1
-        continue-on-error: true
-      - uses: julia-actions/julia-uploadcoveralls@v0.1
-        continue-on-error: true
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - name: Cache artifacts
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-uploadcodecov@v0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Manifest.toml

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -13,9 +13,7 @@ using Base.BinaryPlatforms: AbstractPlatform, HostPlatform
 using Base: SHA1
 
 # We are mimicking Pkg.Artifacts.ensure_artifact_installed here so that we can
-# check if the artifact is already installed before loading Pkg.
-# Then if we need to load Pkg we do it in a subprocess to avoid precompilation
-# complexity.
+# check if the artifact is already installed before loading Pkg, then load if needed.
 
 """
        ensure_artifact_installed(name::String, artifacts_toml::String;
@@ -54,7 +52,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
     if !artifact_exists(hash)
         # loading Pkg is a bit slow, so we only do it if we need to
         if Base.generating_output()
-            # if precompiling load and use Pkg in a subprocess to avoid precompilation complexity
+            # if precompiling, load and use Pkg in a subprocess to avoid precompilation complexity
             code = """
             Pkg = Base.require_stdlib($pkg_pkgid);
             Pkg.Artifacts.try_artifact_download_sources(

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -72,7 +72,8 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
             return Meta.parse(out)
         else
             Pkg = Base.require_stdlib(pkg_pkgid);
-            return Pkg.Artifacts.try_artifact_download_sources(name, hash, meta, artifacts_toml; platform, verbose, quiet_download, io)
+            return @invokelatest Pkg.Artifacts.try_artifact_download_sources(name, hash, meta, artifacts_toml;
+                                                platform, verbose, quiet_download, io)
         end
     else
         return artifact_path(hash)

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -73,4 +73,8 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
     end
 end
 
+if Base.generating_output()
+    precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Base.Val{LazyArtifacts}})
+end
+
 end

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -50,7 +50,7 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
         # and do it in a subprocess to avoid precompilation complexity
         code = """
             Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
-            ret = Pkg.Artifacts.try_artifact_download_sources(
+            Pkg.Artifacts.try_artifact_download_sources(
                 $(repr(name)),
                 Base.$(repr(hash)),
                 $(repr(meta)),
@@ -60,10 +60,9 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
                 quiet_download = $(repr(quiet_download)),
                 io = stderr
             )
-            println(stdout, ret)
         """
-        ret = String(readchomp(pipeline(`$(Base.julia_cmd()) -e $code`, stderr=io)))
-        return ret
+        out = readchomp(pipeline(`$(Base.julia_cmd()) -E $code`, stderr=io))
+        return Meta.parse(out)
     else
         return artifact_path(hash)
     end

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -48,19 +48,20 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
     if !artifact_exists(hash)
         # loading Pkg is a bit slow, so we only do it if we need to
         # and do it in a subprocess to avoid precompilation complexity
-        return read(`$(Base.julia_cmd()) -E '
-        Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
-        Pkg.try_artifact_download_sources(
-               $(repr(name)),
-               $(repr(hash)),
-               $(repr(meta)),
-               $(repr(artifacts_toml));
-               $(repr(platform)),
-               $(repr(verbose)),
-               $(repr(quiet_download)),
-               $(repr(io))
-        )'
-        `, String)
+        cmd = run(pipeline(`$(Base.julia_cmd()) -E '
+                Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
+                Pkg.try_artifact_download_sources(
+                    $(repr(name)),
+                    $(repr(hash)),
+                    $(repr(meta)),
+                    $(repr(artifacts_toml));
+                    platform = $(repr(platform)),
+                    verbose = $(repr(verbose)),
+                    quiet_download = $(repr(quiet_download)),
+                    io = $(repr(io))
+                )'`,
+            stderr=stderr))
+        return read(cmd, String)
     else
         return artifact_path(hash)
     end

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -48,20 +48,22 @@ function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::Str
     if !artifact_exists(hash)
         # loading Pkg is a bit slow, so we only do it if we need to
         # and do it in a subprocess to avoid precompilation complexity
-        cmd = run(pipeline(`$(Base.julia_cmd()) -E '
-                Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
-                Pkg.try_artifact_download_sources(
-                    $(repr(name)),
-                    $(repr(hash)),
-                    $(repr(meta)),
-                    $(repr(artifacts_toml));
-                    platform = $(repr(platform)),
-                    verbose = $(repr(verbose)),
-                    quiet_download = $(repr(quiet_download)),
-                    io = $(repr(io))
-                )'`,
-            stderr=stderr))
-        return read(cmd, String)
+        code = """
+            Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
+            ret = Pkg.Artifacts.try_artifact_download_sources(
+                $(repr(name)),
+                Base.$(repr(hash)),
+                $(repr(meta)),
+                $(repr(artifacts_toml));
+                platform = Base.BinaryPlatforms.$(repr(platform)),
+                verbose = $(repr(verbose)),
+                quiet_download = $(repr(quiet_download)),
+                io = stderr
+            )
+            println(stdout, ret)
+        """
+        ret = String(readchomp(pipeline(`$(Base.julia_cmd()) -e $code`, stderr=io)))
+        return ret
     else
         return artifact_path(hash)
     end

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -12,6 +12,11 @@ export artifact_exists, artifact_path, artifact_meta, artifact_hash,
 using Base.BinaryPlatforms: AbstractPlatform, HostPlatform
 using Base: SHA1
 
+# We are mimicking Pkg.Artifacts.ensure_artifact_installed here so that we can
+# check if the artifact is already installed before loading Pkg.
+# Then if we need to load Pkg we do it in a subprocess to avoid precompilation
+# complexity.
+
 """
        ensure_artifact_installed(name::String, artifacts_toml::String;
                                    platform::AbstractPlatform = HostPlatform(),

--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -9,7 +9,61 @@ using Artifacts: Artifacts,
 export artifact_exists, artifact_path, artifact_meta, artifact_hash,
        select_downloadable_artifacts, find_artifacts_toml, @artifact_str
 
-# define a function for satisfying lazy Artifact downloads
-using Pkg.Artifacts: ensure_artifact_installed
+using Base.BinaryPlatforms: AbstractPlatform, HostPlatform
+using Base: SHA1
+
+"""
+       ensure_artifact_installed(name::String, artifacts_toml::String;
+                                   platform::AbstractPlatform = HostPlatform(),
+                                   pkg_uuid::Union{Base.UUID,Nothing}=nothing,
+                                   verbose::Bool = false,
+                                   quiet_download::Bool = false,
+                                   io::IO=stderr)
+
+Ensures an artifact is installed, downloading it via the download information stored in
+`artifacts_toml` if necessary.  Throws an error if unable to install.
+"""
+function ensure_artifact_installed(name::String, artifacts_toml::String;
+    platform::AbstractPlatform=HostPlatform(),
+    pkg_uuid::Union{Base.UUID,Nothing}=nothing,
+    verbose::Bool=false,
+    quiet_download::Bool=false,
+    io::IO=stderr)
+    meta = artifact_meta(name, artifacts_toml; pkg_uuid=pkg_uuid, platform=platform)
+    if meta === nothing
+        error("Cannot locate artifact '$(name)' in '$(artifacts_toml)'")
+    end
+
+    return ensure_artifact_installed(name, meta, artifacts_toml;
+        platform, verbose, quiet_download, io)
+end
+
+function ensure_artifact_installed(name::String, meta::Dict, artifacts_toml::String;
+    platform::AbstractPlatform=HostPlatform(),
+    verbose::Bool=false,
+    quiet_download::Bool=false,
+    io::IO=stderr)
+
+    hash = SHA1(meta["git-tree-sha1"])
+    if !artifact_exists(hash)
+        # loading Pkg is a bit slow, so we only do it if we need to
+        # and do it in a subprocess to avoid precompilation complexity
+        return read(`$(Base.julia_cmd()) -E '
+        Pkg = Base.require_stdlib(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"));
+        Pkg.try_artifact_download_sources(
+               $(repr(name)),
+               $(repr(hash)),
+               $(repr(meta)),
+               $(repr(artifacts_toml));
+               $(repr(platform)),
+               $(repr(verbose)),
+               $(repr(quiet_download)),
+               $(repr(io))
+        )'
+        `, String)
+    else
+        return artifact_path(hash)
+    end
+end
 
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55725

## This PR

```
julia> @time using MicroMamba
  0.195992 seconds (343.78 k allocations: 18.925 MiB, 19.03% gc time, 78.26% compilation time: 99% of which was recompilation)
```
```
julia> @time @time_imports using MicroMamba
      0.6 ms  Printf
     15.5 ms  Dates
      0.4 ms  Scratch
     10.9 ms  LazyArtifacts
      0.6 ms  TOML
      7.8 ms  Preferences
      0.4 ms  JLLWrappers
               ┌ 120.3 ms micromamba_jll.__init__() 99.79% compilation time (98% recompilation)
    222.6 ms  micromamba_jll 99.59% compilation time (99% recompilation)
      0.4 ms  MicroMamba
  0.271243 seconds (808.59 k allocations: 43.782 MiB, 14.78% gc time, 82.66% compilation time: 99% of which was recompilation)
```

## julia master
```
julia> @time using MicroMamba
  0.355640 seconds (610.25 k allocations: 39.037 MiB, 13.60% gc time, 14.79% compilation time: 100% of which was recompilation)
```

```
julia> @time @time_imports using MicroMamba
      0.5 ms  Printf
     11.7 ms  Dates
      0.3 ms  Scratch
      0.3 ms  TOML
               ┌ 0.0 ms NetworkOptions.__init__()
      1.0 ms  NetworkOptions
               ┌ 0.8 ms MbedTLS_jll.__init__()
      2.6 ms  MbedTLS_jll
               ┌ 0.3 ms LibSSH2_jll.__init__()
      2.0 ms  LibSSH2_jll
               ┌ 0.6 ms LibGit2_jll.__init__()
      2.1 ms  LibGit2_jll
      6.9 ms  LibGit2
      5.5 ms  ArgTools
               ┌ 0.3 ms nghttp2_jll.__init__()
      1.8 ms  nghttp2_jll
               ┌ 0.6 ms LibCURL_jll.__init__()
      2.3 ms  LibCURL_jll
               ┌ 0.0 ms MozillaCACerts_jll.__init__()
      1.6 ms  MozillaCACerts_jll
               ┌ 0.0 ms LibCURL.__init__()
      0.9 ms  LibCURL
               ┌ 2.9 ms Downloads.Curl.__init__()
     15.4 ms  Downloads
      0.7 ms  Tar
               ┌ 0.0 ms p7zip_jll.__init__()
      2.1 ms  p7zip_jll
      0.3 ms  UUIDs
      0.2 ms  Logging
               ┌ 0.0 ms Pkg.__init__()
    221.1 ms  Pkg
      0.5 ms  LazyArtifacts
      7.3 ms  Preferences
      0.5 ms  JLLWrappers
               ┌ 50.3 ms micromamba_jll.__init__() 99.61% compilation time (100% recompilation)
    126.1 ms  micromamba_jll 99.23% compilation time (75% recompilation)
      0.5 ms  MicroMamba
  0.447403 seconds (1.07 M allocations: 63.718 MiB, 15.97% gc time, 28.90% compilation time: 76% of which was recompilation)
```