### PR TITLE
Add precompile statements for `Val{LazyArtifacts}` artifact dispatch.

### DIFF
--- a/src/LazyArtifacts.jl
+++ b/src/LazyArtifacts.jl
@@ -12,4 +12,11 @@ export artifact_exists, artifact_path, artifact_meta, artifact_hash,
 # define a function for satisfying lazy Artifact downloads
 using Pkg.Artifacts: ensure_artifact_installed
 
+# Precompile the `Val{LazyArtifacts}` flavour of `@artifact_str` dispatch so that
+# JLL packages using `using LazyArtifacts` don't pay codegen cost at `__init__`.
+precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, SubString{String}, String,
+                 Dict{String,Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Val{LazyArtifacts}})
+precompile(Tuple{typeof(Artifacts.__artifact_str), Module, String, SubString{String}, String,
+                 Dict{String,Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Val{LazyArtifacts}})
+
 end


### PR DESCRIPTION
Avoids load-time codegen in JLL packages using `using LazyArtifacts`.

x-ref https://github.com/JuliaPackaging/JLLWrappers.jl/pull/88